### PR TITLE
Bumping memory of mig-controller to account for fusor/mig-controller issue #123

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -11,8 +11,8 @@ velero_image: quay.io/ocpmigrate/velero:fusor-dev
 velero_plugin_image: quay.io/ocpmigrate/migration-plugin:latest
 restic_pv_host_path: /var/lib/kubelet/pods
 # optional resource limits for controller
-mig_controller_limits_memory: "300Mi"
+mig_controller_limits_memory: "800Mi"
 mig_controller_limits_cpu: "100m"
-mig_controller_requests_memory: "250Mi"
+mig_controller_requests_memory: "350Mi"
 mig_controller_requests_cpu: "100m"
 mig_svc_account: true


### PR DESCRIPTION
Related to: https://github.com/fusor/mig-controller/issues/123

We don't have a fix on the above issue yet, as we add more source clusters the memory needs increase.  We were using 300m and saw issues when running with 2 source clusters.  