### PR TITLE
"Host" MigCluster should deploy with controller, not UI

### DIFF
--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -383,3 +383,12 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
+
+---
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigCluster
+metadata:
+  name: "{{ cluster_name }}"
+  namespace: "{{ mig_namespace}}"
+spec:
+  isHostCluster: true

--- a/roles/migrationcontroller/templates/ui.yml.j2
+++ b/roles/migrationcontroller/templates/ui.yml.j2
@@ -1,12 +1,4 @@
 ---
-apiVersion: migration.openshift.io/v1alpha1
-kind: MigCluster
-metadata:
-  name: "{{ cluster_name }}"
-  namespace: "{{ mig_namespace}}"
-spec:
-  isHostCluster: true
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Thinking it may make more sense for the 'host' MigCluster to get deployed alongside the controller 
```
migration_controller: true
```
Rather than with the UI 
```
migration_ui: true
```
Since the controller "owns" all of the CRDs (incl. MigCluster) and it would be helpful to have the 'host' MigCluster even if you're running without the UI.
