### PR TITLE
Changed default mig controller namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once you've made your configuration choices run `oc create -f controller.yml`.
 In order to enable the UI to talk to an Openshift 3 cluster (whether local or remote) it is necessary to edit the master-config.yaml and restart the Openshift master nodes. 
 
 To determine the CORS URL that needs to be added retrieve the route URL after installing the controller.
-`oc get -n mig route/migration -o go-template='{{ .spec.host }}{{ println }}'`
+`oc get -n openshift-migration-operator route/migration -o go-template='{{ .spec.host }}{{ println }}'`
 
 Add the hostname to /etc/origin/master/master-config.yaml under corsAllowedOrigins, for instance:
 ```
@@ -52,7 +52,7 @@ corsAllowedOrigins:
 On Openshift 4 cluster resources are modified by the operator if the controller is installed there and you can skip these steps. If you chose not to install the controller on your Openshift 4 cluster you will need to perform these steps manually.
 
 If you haven't already, determine the CORS URL that needs to be added retrieve the route URL
-`oc get -n mig route/migration -o go-template='{{ .spec.host }}{{ println }}'`
+`oc get -n openshift-migration-operator route/migration -o go-template='{{ .spec.host }}{{ println }}'`
 
 `oc edit authentication.operator cluster` and ensure the following exist:
 ```
@@ -77,13 +77,12 @@ When adding a remote cluster in the migration UI you will be prompted for a serv
 
 To get a serviceaccount token use the following command:
 ```
-oc sa get-token -n mig mig
+oc sa get-token -n openshift-migration-operator mig
 ```
 
 ## Cleanup
 To clean up all the resources created by the operator you can do the following:
 ```
-oc delete namespace mig
 
 oc delete crd backups.velero.io backupstoragelocations.velero.io deletebackuprequests.velero.io downloadrequests.velero.io migrationcontrollers.migration.openshift.io podvolumebackups.velero.io podvolumerestores.velero.io resticrepositories.velero.io restores.velero.io schedules.velero.io serverstatusrequests.velero.io volumesnapshotlocations.velero.io
 
@@ -91,5 +90,7 @@ oc delete clusterrolebindings migration-operator velero mig-cluster-admin
 
 oc delete oauthclient migration
 
-oc delete scc velero-privileged
+oc delete namespace openshift-migration
+
+oc delete namespace openshift-migration-operator
 ```

--- a/README.md
+++ b/README.md
@@ -83,14 +83,13 @@ oc sa get-token -n openshift-migration-operator mig
 ## Cleanup
 To clean up all the resources created by the operator you can do the following:
 ```
+oc delete namespace openshift-migration
+
+oc delete namespace openshift-migration-operator
 
 oc delete crd backups.velero.io backupstoragelocations.velero.io deletebackuprequests.velero.io downloadrequests.velero.io migrationcontrollers.migration.openshift.io podvolumebackups.velero.io podvolumerestores.velero.io resticrepositories.velero.io restores.velero.io schedules.velero.io serverstatusrequests.velero.io volumesnapshotlocations.velero.io
 
 oc delete clusterrolebindings migration-operator velero mig-cluster-admin
 
 oc delete oauthclient migration
-
-oc delete namespace openshift-migration
-
-oc delete namespace openshift-migration-operator
 ```

--- a/controller.yml
+++ b/controller.yml
@@ -2,7 +2,7 @@ apiVersion: migration.openshift.io/v1alpha1
 kind: MigrationController
 metadata:
   name: migration-controller
-  namespace: mig
+  namespace: openshift-migration-operator
 spec:
   cluster_name: host
   migration_velero: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: openshift-migration-operator
   labels:
     app: migration-operator
 spec:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: migration-operator
-  namespace: mig
+  namespace: openshift-migration-operator
 rules:
 - apiGroups:
   - ""

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: openshift-migration-operator
 subjects:
 - kind: ServiceAccount
   name: migration-operator
@@ -23,5 +23,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: migration-operator
-    namespace: mig
-namespace: mig
+    namespace: openshift-migration-operator
+namespace: openshift-migration-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: openshift-migration-operator

--- a/molecule/default/asserts.yml
+++ b/molecule/default/asserts.yml
@@ -6,11 +6,11 @@
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
   tasks:
-    - name: Get all pods in {{ namespace }}
+    - name: Get all pods in {{ controller_namespace }}
       k8s_facts:
         api_version: v1
         kind: Pod
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
       register: pods
 
     - name: Output pods

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,7 +28,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-mig}
+        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
   env:
     K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
     KUBECONFIG: /tmp/molecule/kind-default/kubeconfig

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,7 +28,9 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
+        controller_namespace: ${TEST_CONTROLLER_NAMESPACE:-openshift-migration-operator}
+        migration_namespace: ${TEST_MIGRATION_NAMESPACE:-openshift-migration}
+
   env:
     K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
     KUBECONFIG: /tmp/molecule/kind-default/kubeconfig

--- a/molecule/test-cluster/molecule.yml
+++ b/molecule/test-cluster/molecule.yml
@@ -18,7 +18,8 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
+        controller_namespace: ${TEST_CONTROLLER_NAMESPACE:-openshift-migration-operator}
+        migration_namespace: ${TEST_MIGRATION_NAMESPACE:-openshift-migration}
   lint:
     name: ansible-lint
     enabled: False

--- a/molecule/test-cluster/molecule.yml
+++ b/molecule/test-cluster/molecule.yml
@@ -18,7 +18,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-mig}
+        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
   lint:
     name: ansible-lint
     enabled: False

--- a/molecule/test-cluster/playbook.yml
+++ b/molecule/test-cluster/playbook.yml
@@ -11,18 +11,18 @@
   tasks:
   - name: Create the migration.openshift.io/v1alpha1.MigrationController
     k8s:
-      namespace: '{{ namespace }}'
+      namespace: '{{ controller_namespace }}'
       definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/migration_v1alpha1_migration_cr.yaml'])) }}"
 
   - name: Get the newly created Custom Resource
     debug:
-      msg: "{{ lookup('k8s', group='migration.openshift.io', api_version='v1alpha1', kind='MigrationController', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
+      msg: "{{ lookup('k8s', group='migration.openshift.io', api_version='v1alpha1', kind='MigrationController', namespace=controller_namespace, resource_name=custom_resource.metadata.name) }}"
 
   - name: Wait 40s for reconciliation to run
     k8s_facts:
       api_version: 'v1alpha1'
       kind: 'MigrationController'
-      namespace: '{{ namespace }}'
+      namespace: '{{ controller_namespace }}'
       name: '{{ custom_resource.metadata.name }}'
     register: reconcile_cr
     until:

--- a/molecule/test-local/molecule.yml
+++ b/molecule/test-local/molecule.yml
@@ -30,7 +30,9 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
+        controller_namespace: ${TEST_CONTROLLER_NAMESPACE:-openshift-migration-operator}
+        migration_namespace: ${TEST_MIGRATION_NAMESPACE:-openshift-migration}
+        test_image: ${REPLACE_IMAGE:-quay.io/ocpmigrate/mig-operator:test}
   env:
     K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
     KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig

--- a/molecule/test-local/molecule.yml
+++ b/molecule/test-local/molecule.yml
@@ -30,7 +30,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-mig}
+        namespace: ${TEST_NAMESPACE:-openshift-migration-operator}
   env:
     K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
     KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig

--- a/molecule/test-local/playbook.yml
+++ b/molecule/test-local/playbook.yml
@@ -2,17 +2,15 @@
 
 - name: Build Operator in Kubernetes docker container
   hosts: k8s
-  vars:
-    image_name: migration.openshift.io/mig-operator:testing
   tasks:
   # using command so we don't need to install any dependencies
   - name: Get existing image hash
-    command: docker images -q {{ image_name }}
+    command: docker images -q {{ test_image }}
     register: prev_hash
     changed_when: false
 
   - name: Build Operator Image
-    command: docker build -f /build/build/Dockerfile -t {{ image_name }} /build
+    command: docker build -f /build/build/Dockerfile -t {{ test_image }} /build
     register: build_cmd
     changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
 
@@ -23,14 +21,13 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
     deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     pull_policy: Never
-    REPLACE_IMAGE: migration.openshift.io/mig-operator:testing
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/migration_v1alpha1_migration_cr.yaml'])) | from_yaml }}"
   tasks:
   - block:
     - name: Delete the Operator Deployment
       k8s:
         state: absent
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
         definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
       register: delete_deployment
       when: hostvars[groups.k8s.0].build_cmd.changed
@@ -39,7 +36,7 @@
       k8s_facts:
         api_version: '{{ definition.apiVersion }}'
         kind: '{{ definition.kind }}'
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
         name: '{{ definition.metadata.name }}'
       vars:
         definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
@@ -49,28 +46,37 @@
       retries: 10
       when: delete_deployment.changed
 
+    - name: "Replace latest image with {{ test_image }}"
+      replace:
+        path: "{{ deploy_dir }}/operator.yaml"
+        regexp: '^(.*)image:( *)quay.io/ocpmigrate/mig-operator(.*)$'
+        replace: "\\1image:\\2{{ test_image }}"
+
+    - debug:
+        msg: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+
     - name: Create the Operator Deployment
       k8s:
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
         definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
 
     - name: Create the migration.openshift.io/v1alpha1.MigrationController
       k8s:
         state: present
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
         definition: '{{ custom_resource }}'
 
-    - name: Wait 120s for reconciliation to run
+    - name: Wait 240s for reconciliation to run
       k8s_facts:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
-        namespace: '{{ namespace }}'
+        namespace: '{{ controller_namespace }}'
         name: '{{ custom_resource.metadata.name }}'
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
       delay: 10
-      retries: 12
+      retries: 24
     rescue:
     - name: debug cr
       ignore_errors: yes
@@ -81,7 +87,7 @@
         debug_cr: '{{ lookup("k8s",
           kind=custom_resource.kind,
           api_version=custom_resource.apiVersion,
-          namespace=namespace,
+          namespace=controller_namespace,
           resource_name=custom_resource.metadata.name
         )}}'
 
@@ -94,14 +100,14 @@
         deploy: '{{ lookup("k8s",
           kind="Deployment",
           api_version="apps/v1",
-          namespace=mig,
+          namespace=controller_namespace,
           label_selector="app=migration-operator"
         )}}'
 
     - name: get operator logs
       ignore_errors: yes
       failed_when: false
-      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ controller_namespace }}
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:

--- a/molecule/test-local/prepare.yml
+++ b/molecule/test-local/prepare.yml
@@ -12,16 +12,22 @@
     k8s:
       definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/migration_v1alpha1_migration_crd.yaml'])) }}"
 
-  - name: Ensure specified namespace is present
+  - name: Ensure controller namespace is present
     k8s:
       api_version: v1
       kind: Namespace
-      name: '{{ namespace }}'
+      name: '{{ controller_namespace }}'
+
+  - name: Ensure migration namespace is present
+    k8s:
+      api_version: v1
+      kind: Namespace
+      name: '{{ migration_namespace }}'
 
   - name: Create RBAC resources
     k8s:
       definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
-      namespace: '{{ namespace }}'
+      namespace: '{{ controller_namespace }}'
     with_items:
       - role.yaml
       - role_binding.yaml

--- a/operator.yml
+++ b/operator.yml
@@ -5,13 +5,13 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
-  name: mig
+  name: "openshift-migration-operator"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: "openshift-migration-operator"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -38,7 +38,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: migration-operator
-  namespace: mig
+  namespace: "openshift-migration-operator"
 rules:
 - apiGroups:
   - ""
@@ -87,7 +87,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: "openshift-migration-operator"
 subjects:
 - kind: ServiceAccount
   name: migration-operator
@@ -107,14 +107,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: migration-operator
-    namespace: mig
-namespace: mig
+    namespace: "openshift-migration-operator"
+namespace: "openshift-migration-operator"
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: migration-operator
-  namespace: mig
+  namespace: "openshift-migration-operator"
   labels:
     app: migration-operator
 spec:

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
 mig_controller_image: quay.io/ocpmigrate/mig-controller
 mig_controller_version: "{{ snapshot_tag | default('latest') }}"
-mig_namespace: mig
+mig_resources_namespace: openshift-migration
+mig_manager_namespace: openshift-migration-operator
 mig_ui_configmap_name : mig-ui-config
+mig_ui_config_namespace: openshift-config
 mig_ui_oauth_user_scope: "user:full"
 mig_ui_image: quay.io/ocpmigrate/mig-ui
 mig_ui_version: "{{ snapshot_tag | default('latest') }}"

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -34,6 +34,21 @@ spec:
               type: boolean
             serviceAccountSecretRef:
               type: object
+            storageClasses:
+              items:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                  default:
+                    type: boolean
+                  name:
+                    type: string
+                  provisioner:
+                    type: string
+                type: object
+              type: array
           required:
           - isHostCluster
           type: object

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -38,6 +38,49 @@ spec:
               items:
                 type: string
               type: array
+            persistentVolumes:
+              items:
+                properties:
+                  capacity:
+                    type: string
+                  name:
+                    type: string
+                  pvc:
+                    properties:
+                      accessModes:
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  selection:
+                    properties:
+                      accessMode:
+                        type: string
+                      action:
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                  storageClass:
+                    type: string
+                  supported:
+                    properties:
+                      actions:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - actions
+                    type: object
+                required:
+                - supported
+                - selection
+                type: object
+              type: array
             srcMigClusterRef:
               type: object
           type: object

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -101,9 +101,8 @@
       state: "{{ controller_state }}"
       definition: "{{ lookup('template', 'controller.yml.j2') }}"
 
-- name: migration_ui
+- when: migration_ui
   block:
-
   - name: Check if mig ui route exists already so we don't update it
     k8s_facts:
       api_version: v1
@@ -111,13 +110,12 @@
       name: migration
       namespace: "{{ mig_manager_namespace }}"
     register: route_status
-    when: migration_ui
 
   - name: "Set up mig ui route"
     k8s:
       state: "{{ ui_state }}"
       definition: "{{ lookup('template', 'ui-route.yml.j2') }}"
-    when: migration_ui and (route_status.resources|length) == 0
+    when: (route_status.resources|length) == 0
 
   - name: Find generated route
     k8s_facts:
@@ -126,19 +124,16 @@
       namespace: "{{ mig_manager_namespace }}"
       name: migration
     register: route
-    when: migration_ui
 
   - name: Determine CORS URL
     set_fact:
       mig_ui_cors_url: "//{{ route.resources[0].spec.host }}"
       mig_ui_cors_loopback: "//127.0.0.1(:|$)"
       mig_ui_cors_localhost: "//localhost(:|$)"
-    when: migration_ui
 
   - name: Set OAuth redirect url
     set_fact:
       mig_ui_oauth_redirect_url: "https:{{ mig_ui_cors_url }}/login/callback"
-    when: migration_ui
 
   - name: Check if migration ui oauthclient secret exists already so we don't update it
     k8s_facts:
@@ -147,17 +142,16 @@
       name: migration
       namespace: "{{ mig_manager_namespace }}"
     register: oauthclient_status
-    when: migration_ui
 
   - name: Generate random secret value for oauth client
     set_fact:
       mig_ui_oauth_secret: "{{ 99999999 | random | to_uuid | b64encode }}"
-    when: migration_ui and (oauthclient_status.resources|length) == 0
+    when: (oauthclient_status.resources|length) == 0
 
   - name: Use existing secret value for oauth client
     set_fact:
       mig_ui_oauth_secret: "{{ oauthclient_status.resources[0].secret }}"
-    when: migration_ui and (oauthclient_status.resources|length) > 0
+    when: (oauthclient_status.resources|length) > 0
 
   - name: Set up mig ui oauthclient secret
     k8s:
@@ -327,10 +321,9 @@
     k8s:
       state: "present"
       definition: "{{ lookup('template', 'mig_service_account.yml.j2') }}"
-  
+
 - when: migration_controller or migration_ui
   name: "Set up host MigCluster"
   k8s:
     state: "present"
     definition: "{{ lookup('template', 'mig_host_cluster.yml.j2') }}"
-  

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -9,10 +9,15 @@
 - set_fact: velero_state="present"
   when: migration_velero
 
-- name: "Set up mig namespace"
+- name: "Set up namespace for mig resources"
   k8s:
     state: "present"
     definition: "{{ lookup('template', 'mig_namespace.yml.j2') }}"
+
+- name: "Set up mig operator namespace"
+  k8s:
+    state: "present"
+    definition: "{{ lookup('template', 'mig_manager_namespace.yml.j2') }}"
   when: migration_ui or migration_controller or migration_velero
 
 #This ConfigMap contains the cluster config on Openshift 4.
@@ -47,17 +52,16 @@
   when:
   - cluster_configmap.resources|length == 0
   - origin_three_dev is defined and origin_three_dev
-    
-- name: migration_velero
+
+- when: migration_velero
   block:
   - name: Check if cloud-credentials secret exists already so we don't update it
     k8s_facts:
       api_version: v1
       kind: Secret
       name: "{{ velero_aws_secret_name }}"
-      namespace: "{{ mig_namespace }}"
+      namespace: "{{ mig_resources_namespace }}"
     register: secret_status
-    when: migration_velero
 
   - name: "Create empty velero S3 secret"
     k8s:
@@ -67,10 +71,10 @@
         kind: Secret
         metadata:
           name: "{{ velero_aws_secret_name }}"
-          namespace: "{{ mig_namespace }}"
+          namespace: "{{ mig_resources_namespace }}"
         data:
           cloud: ""
-    when: migration_velero and (secret_status.resources|length) == 0
+    when: (secret_status.resources|length) == 0
 
   - name: "Set up velero controller"
     k8s:
@@ -105,7 +109,7 @@
       api_version: v1
       kind: Route
       name: migration
-      namespace: "{{ mig_namespace }}"
+      namespace: "{{ mig_manager_namespace }}"
     register: route_status
     when: migration_ui
 
@@ -119,7 +123,7 @@
     k8s_facts:
       api_version: "route.openshift.io/v1"
       kind: "Route"
-      namespace: "{{ mig_namespace }}"
+      namespace: "{{ mig_manager_namespace }}"
       name: migration
     register: route
     when: migration_ui
@@ -141,7 +145,7 @@
       api_version: v1
       kind: OAuthClient
       name: migration
-      namespace: "{{ mig_namespace }}"
+      namespace: "{{ mig_manager_namespace }}"
     register: oauthclient_status
     when: migration_ui
 
@@ -165,7 +169,7 @@
       api_version: v1
       kind: ConfigMap
       name: "{{ mig_ui_configmap_name }}"
-      namespace: "{{ mig_namespace }}"
+      namespace: "{{ mig_manager_namespace }}"
     register: configmap_status
 
   - name: Set up mig ui configmap

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -6,26 +6,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - namespaces/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
   - migration.openshift.io
   resources:
   - migclusters
@@ -106,6 +86,62 @@ rules:
   - update
   - patch
 - apiGroups:
+  - apps.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - ""
   resources:
   - pods
@@ -168,26 +204,6 @@ rules:
 - apiGroups:
   - migration.openshift.io
   resources:
-  - migstages
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - migration.openshift.io
-  resources:
-  - migstages/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - migration.openshift.io
-  resources:
   - migstorages
   verbs:
   - get
@@ -230,9 +246,9 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - apps.openshift.io
+  - storage.k8s.io
   resources:
-  - '*'
+  - storageclasses
   verbs:
   - get
   - list
@@ -241,6 +257,106 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secret
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secret/status
+  verbs:
+  - get
+  - update
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -278,14 +394,7 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -298,13 +298,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-server-secret
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}
 ---
 apiVersion: v1
 kind: Service
@@ -313,7 +313,7 @@ metadata:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: controller-manager-service
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}
 spec:
   ports:
   - port: 443
@@ -328,7 +328,7 @@ metadata:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: controller-manager
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}
 spec:
   selector:
     matchLabels:

--- a/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
+++ b/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
@@ -3,6 +3,6 @@ apiVersion: migration.openshift.io/v1alpha1
 kind: MigCluster
 metadata:
   name: "{{ cluster_name }}"
-  namespace: "{{ mig_namespace}}"
+  namespace: "{{ mig_resources_namespace }}"
 spec:
   isHostCluster: true

--- a/roles/migrationcontroller/templates/mig_manager_namespace.yml.j2
+++ b/roles/migrationcontroller/templates/mig_manager_namespace.yml.j2
@@ -5,4 +5,4 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
-  name: {{ mig_resources_namespace }}
+  name: {{ mig_manager_namespace }}

--- a/roles/migrationcontroller/templates/mig_service_account.yml.j2
+++ b/roles/migrationcontroller/templates/mig_service_account.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mig
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}
   labels:
     component: mig
 ---
@@ -18,4 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: mig
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_manager_namespace }}

--- a/roles/migrationcontroller/templates/ui-configmap.yml.j2
+++ b/roles/migrationcontroller/templates/ui-configmap.yml.j2
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ mig_ui_configmap_name }}"
-  namespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_manager_namespace }}"
 data:
   migmeta.json: '{{ mig_ui_configmap_data | to_json }}'

--- a/roles/migrationcontroller/templates/ui-oauthsecret.yml.j2
+++ b/roles/migrationcontroller/templates/ui-oauthsecret.yml.j2
@@ -3,7 +3,7 @@ apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
   name: migration
-  namespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_manager_namespace }}"
 grantMethod: auto
 redirectURIs: ["{{ mig_ui_oauth_redirect_url }}"]
 secret: "{{ mig_ui_oauth_secret }}"

--- a/roles/migrationcontroller/templates/ui-route.yml.j2
+++ b/roles/migrationcontroller/templates/ui-route.yml.j2
@@ -5,7 +5,7 @@ metadata:
   annotations:
     haproxy.router.openshift.io/timeout: 300s
   name: migration
-  namespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_manager_namespace }}"
   labels:
     app: migration
     service: migration

--- a/roles/migrationcontroller/templates/ui.yml.j2
+++ b/roles/migrationcontroller/templates/ui.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: migration-ui
-  namespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_manager_namespace }}"
   labels:
     app: migration
     service: migration-ui
@@ -21,7 +21,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: migration-ui
-  namespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_manager_namespace }}"
   labels:
     app: migration
     service: migration-ui

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -157,7 +157,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: velero
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_resources_namespace }}
   labels:
     component: velero
 ---
@@ -169,7 +169,7 @@ metadata:
     component: velero
 subjects:
   - kind: ServiceAccount
-    namespace: {{ mig_namespace }}
+    namespace: {{ mig_resources_namespace }}
     name: velero
 roleRef:
   kind: ClusterRole
@@ -214,14 +214,14 @@ supplementalGroups:
   type: RunAsAny
 users:
 - system:admin
-- system:serviceaccount:{{ mig_namespace }}:velero
+- system:serviceaccount:{{ mig_resources_namespace }}:velero
 volumes:
 - '*'
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_resources_namespace }}
   name: velero
 spec:
   replicas: 1
@@ -283,7 +283,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: restic
-  namespace: {{ mig_namespace }}
+  namespace: {{ mig_resources_namespace }}
 spec:
   selector:
     matchLabels:

--- a/roles/migrationcontroller/vars/main.yml
+++ b/roles/migrationcontroller/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 mig_ui_configmap_data:
   clusterApi: "{{ mig_ui_cluster_api_endpoint }}"
-  namespace: "{{ mig_namespace }}"
-  configNamespace: "{{ mig_namespace }}"
+  namespace: "{{ mig_resources_namespace }}"
+  configNamespace: "{{ mig_ui_config_namespace }}"
   oauth:
     clientId: migration
     redirectUrl: "{{ mig_ui_oauth_redirect_url }}"


### PR DESCRIPTION
Decoupling mig-controller CRs from the controllers - https://github.com/fusor/mig-controller/issues/220
```
dgrigore mig-operator  $ oc get ns | grep migration
openshift-migration                                     Active    9h
openshift-migration-operator                            Active    7h33m
dgrigore mig-operator  $ oc get pods -n openshift-migration
NAME                                READY     STATUS      RESTARTS   AGE
registry-mig-nginx-wbnbj-1-deploy   0/1       Completed   0          6h48m
registry-mig-nginx-wbnbj-1-n8qf7    1/1       Running     0          6h48m
registry-statefull-5sk2t-1-deploy   0/1       Completed   0          6h22m
registry-statefull-5sk2t-1-k4n98    1/1       Running     0          6h22m
registry-stateless-7mgmn-1-deploy   0/1       Completed   0          6h24m
registry-stateless-7mgmn-1-tnzj6    1/1       Running     0          6h24m
registry-stateless-rhkhl-1-deploy   0/1       Completed   0          6h25m
registry-stateless-rhkhl-1-kg5ql    1/1       Running     0          6h25m
restic-swrdn                        1/1       Running     0          9h
restic-zmvcw                        1/1       Running     0          9h
velero-6bf58f4f88-gw79s             1/1       Running     0          9h
dgrigore mig-operator  $ oc get pods -n openshift-migration-operator
NAME                                  READY     STATUS    RESTARTS   AGE
controller-manager-cc8c6d5c6-27wqs    1/1       Running   0          6h26m
migration-operator-5c49594f75-nh5zq   2/2       Running   0          7h33m
migration-ui-8d7d66bb-44tfd           1/1       Running   0          7h33m
dgrigore mig-operator  $ oc get migplans -n openshift-migration
NAME        AGE
statefull   6h22m
stateless   6h25m

```

Other changes:
- Updated RBAC with a generated ones from [mig-plan annotations](https://github.com/fusor/mig-controller/pull/250/files#diff-78c6d854c5e343bf8121a5e196e0d5b5R147-R151) and [remote-watcher annotations] (https://github.com/fusor/mig-controller/pull/250/files#diff-a17618455181a0d9760b07009c5075afR193-R203), which was tested on reenabled finalizers. 
- Moved `mig-ui` configuration to the `openshift-config` namespace.