### PR TITLE
BZ 1737577 - Don't attempt removing CRDs by setting state 'absent'

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -20,7 +20,6 @@ mig_svc_account: true
 ui_state: absent
 controller_state: absent
 velero_state: absent
-crd_state: absent
 # defaults to help with templating during deletion
 mig_ui_oauth_redirect_url: ""
 mig_ui_oauth_secret: ""

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -9,9 +9,6 @@
 - set_fact: velero_state="present"
   when: migration_velero
 
-- set_fact: crd_state="present"
-  when: migration_controller or migration_ui
-
 - name: "Set up mig namespace"
   k8s:
     state: "present"
@@ -85,7 +82,7 @@
 
   - name: "Set up migration CRDs"
     k8s:
-      state: "{{ crd_state }}"
+      state: "present"
       src: "{{ role_path }}/files/{{ item }}"
     with_items:
       - "cluster-registry-crd.yaml"
@@ -93,11 +90,13 @@
       - "migration_v1alpha1_migmigration.yaml"
       - "migration_v1alpha1_migplan.yaml"
       - "migration_v1alpha1_migstorage.yaml"
+    when: migration_controller or migration_ui
 
   - name: "Set up mig controller"
     k8s:
       state: "{{ controller_state }}"
       definition: "{{ lookup('template', 'controller.yml.j2') }}"
+    when: migration_controller
 
 - name: migration_ui
   block:

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -96,7 +96,6 @@
     k8s:
       state: "{{ controller_state }}"
       definition: "{{ lookup('template', 'controller.yml.j2') }}"
-    when: migration_controller
 
 - name: migration_ui
   block:

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -375,12 +375,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
-
----
-apiVersion: migration.openshift.io/v1alpha1
-kind: MigCluster
-metadata:
-  name: "{{ cluster_name }}"
-  namespace: "{{ mig_namespace}}"
-spec:
-  isHostCluster: true


### PR DESCRIPTION
Have tested this successfully on 3.11 and 4.1. 

Had an issue where we would attempt to remove CRs of a GVK that the cluster wasn't aware of, which triggered a fatal error in the ansible playbook. Solved by being sure to only run `state: absent` against base types. 

Deletion of CRs can be handled by wiping the entire CRD off the cluster, or we could also do an exploratory check on the list of CRDs before attempting CR deletion.