### PR TITLE
Add snapshot support

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
 mig_controller_image: quay.io/ocpmigrate/mig-controller
-mig_controller_version: latest
+mig_controller_version: "{{ snapshot_tag | default('latest') }}"
 mig_namespace: mig
 mig_ui_configmap_name : mig-ui-config
 mig_ui_oauth_user_scope: "user:full"
 mig_ui_image: quay.io/ocpmigrate/mig-ui
-mig_ui_version: latest
+mig_ui_version: "{{ snapshot_tag | default('latest') }}"
 velero_aws_secret_name: cloud-credentials
-velero_image: quay.io/ocpmigrate/velero:fusor-dev
-velero_plugin_image: quay.io/ocpmigrate/migration-plugin:latest
+velero_image: "quay.io/ocpmigrate/velero:{{ snapshot_tag | default('fusor-dev') }}"
+velero_plugin_image: "quay.io/ocpmigrate/migration-plugin:{{ snapshot_tag | default('latest') }}"
 restic_pv_host_path: /var/lib/kubelet/pods
 # optional resource limits for controller
 mig_controller_limits_memory: "800Mi"

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+if [[ "$1" == "" ]]; do
+  echo "First argument must be the snapshot tag, received nothing..."
+  echo "Example: snapshot.sh sprint9"
+  exit 1
+done
+
+tag=$1
+
+docker pull quay.io/ocpmigrate/mig-controller:latest
+docker pull quay.io/ocpmigrate/mig-ui:latest
+docker pull quay.io/ocpmigrate/mig-operator:latest
+docker pull quay.io/ocpmigrate/migration-plugin:latest
+docker pull quay.io/ocpmigrate/velero:fusor-dev
+
+docker tag quay.io/ocpmigrate/mig-controller:latest quay.io/ocpmigrate/mig-controller:${tag}
+docker tag quay.io/ocpmigrate/mig-ui:latest quay.io/ocpmigrate/mig-ui:${tag}
+docker tag quay.io/ocpmigrate/mig-operator:latest quay.io/ocpmigrate/mig-operator:${tag}
+docker tag quay.io/ocpmigrate/migration-plugin:latest quay.io/ocpmigrate/migration-plugin:${tag}
+docker tag quay.io/ocpmigrate/velero:fusor-dev quay.io/ocpmigrate/velero:${tag}
+
+docker push quay.io/ocpmigrate/mig-controller:${tag}
+docker push quay.io/ocpmigrate/mig-ui:${tag}
+docker push quay.io/ocpmigrate/mig-operator:${tag}
+docker push quay.io/ocpmigrate/migration-plugin:${tag}
+docker push quay.io/ocpmigrate/velero:${tag}


### PR DESCRIPTION
Adds a script to snapshot all our images with a single tag and push to our various image repos. Also adds a variable that can be set on the migrationcontroller CR to point to a particular snapshot tag, and it will deploy from that tag across the board. If this variable is not set, will use the original default tags.