### PR TITLE
Set velero namespace in env vars for velero deployment

### DIFF
--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -237,6 +237,8 @@ spec:
           env:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
+            - name: VELERO_NAMESPACE
+              value: {{ mig_namespace }}
             - name: VELERO_SCRATCH_DIR
               value: /scratch
       volumes:


### PR DESCRIPTION
This will be needed to fix our CSI migrations as we move to 1.1.

https://github.com/heptio/velero/pull/1748