### PR TITLE
Change controller.yml defaults to OCP 3 recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This operator will install velero with customized migration plugins, the migrati
 
 ## Operator Installation with OLM on Openshift 4
 1. `oc create -f mig-operator-source.yaml`
-1. Create a mig namespace
+1. Create a openshift-migration-operator namespace
 1. In the left menu select Operator Hub and find `Migration Operator` in the list
 1. Click Install and install it in the mig namespace
 1. Once installation is complete select `Installed Operators` on the left menu
@@ -14,7 +14,9 @@ This operator will install velero with customized migration plugins, the migrati
 `oc create -f operator.yml`
 
 ## Migration Controller Installation
-Edit `controller.yml` and adjust desired options
+'controller-3.yml' and 'controller-4.yml' contain the recommended settings for OCP 3 and 4 respectively.
+
+Edit `controller.yml` and adjust options if desired.
 
 Recommended settings for Openshift 3 are:
 ```
@@ -30,7 +32,7 @@ Recommended settings for Openshift 4 are:
   migration_ui: true
 ```
 
-It is possible to reverse this setup and install the controller and UI pods on Openshift 3, but you will also need to provide the cluster endpoint in controller.yml via the `mig_ui_cluster_api_endpoint` parameter. Additional setup will also be required on the Openshift 4 cluster if you take this route. See the manual CORS configuration section below for more details. `migration_velero` is required on every cluster that will act as a source or destination for migrated workloads.
+It is possible to reverse this setup and install the controller and UI pods on Openshift 3, but you will also need to provide the cluster endpoint in `controller-3.yml` via the `mig_ui_cluster_api_endpoint` parameter. Additional setup will also be required on the Openshift 4 cluster if you take this route. See the manual CORS configuration section below for more details. `migration_velero` is required on every cluster that will act as a source or destination for migrated workloads.
 
 Once you've made your configuration choices run `oc create -f controller.yml`.
 

--- a/controller-3.yml
+++ b/controller-3.yml
@@ -1,0 +1,12 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigrationController
+metadata:
+  name: migration-controller
+  namespace: openshift-migration-operator
+spec:
+  cluster_name: host
+  migration_velero: true
+  migration_controller: false
+  migration_ui: false
+  #To install the controller on Openshift 3 you will need to configure the API endpoint:
+  #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443/api

--- a/controller-4.yml
+++ b/controller-4.yml
@@ -8,5 +8,3 @@ spec:
   migration_velero: true
   migration_controller: true
   migration_ui: true
-  #To install the controller on Openshift 3 you will need to configure the API endpoint:
-  #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443/api


### PR DESCRIPTION
The preferred approach for OCP 4 is to use OLM for installation as outlined at:
https://github.com/fusor/mig-operator#operator-installation-with-olm-on-openshift-4

Since the controller.yml is primarily intended as a means of installing components on OCP 3 it makes sense to change the controller.yml defaults to install only what we recommend on OCP 3.

This addresses https://github.com/fusor/mig-operator/issues/37