### PR TITLE
Fix leftover var name from split NS change

### DIFF
--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -257,7 +257,7 @@ spec:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
             - name: VELERO_NAMESPACE
-              value: {{ mig_namespace }}
+              value: {{ mig_resources_namespace }}
             - name: VELERO_SCRATCH_DIR
               value: /scratch
       volumes:


### PR DESCRIPTION
WIP, fixing any issues identified testing after split ns https://github.com/fusor/mig-operator/pull/30.

 - Outdated var name leftover from rebase, `mig_namespace -> mig_resources_namespace`
 - ...