### PR TITLE
Fix apps / deployment RBAC regression

### DIFF
--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -242,6 +242,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - apps
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations


### PR DESCRIPTION
Lost this permission during the unification of `master` and `olm` branches