### PR TITLE
Add velero-restic-restore-helper to snapshot.sh

### DIFF
--- a/snapshot.sh
+++ b/snapshot.sh
@@ -12,15 +12,18 @@ docker pull quay.io/ocpmigrate/mig-ui:latest
 docker pull quay.io/ocpmigrate/mig-operator:latest
 docker pull quay.io/ocpmigrate/migration-plugin:latest
 docker pull quay.io/ocpmigrate/velero:fusor-dev
+docker pull quay.io/ocpmigrate/velero-restic-restore-helper:latest
 
 docker tag quay.io/ocpmigrate/mig-controller:latest quay.io/ocpmigrate/mig-controller:${tag}
 docker tag quay.io/ocpmigrate/mig-ui:latest quay.io/ocpmigrate/mig-ui:${tag}
 docker tag quay.io/ocpmigrate/mig-operator:latest quay.io/ocpmigrate/mig-operator:${tag}
 docker tag quay.io/ocpmigrate/migration-plugin:latest quay.io/ocpmigrate/migration-plugin:${tag}
 docker tag quay.io/ocpmigrate/velero:fusor-dev quay.io/ocpmigrate/velero:${tag}
+docker tag quay.io/ocpmigrate/velero-restic-restore-helper:latest quay.io/ocpmigrate/velero-restic-restore-helper:${tag}
 
 docker push quay.io/ocpmigrate/mig-controller:${tag}
 docker push quay.io/ocpmigrate/mig-ui:${tag}
 docker push quay.io/ocpmigrate/mig-operator:${tag}
 docker push quay.io/ocpmigrate/migration-plugin:${tag}
 docker push quay.io/ocpmigrate/velero:${tag}
+docker push quay.io/ocpmigrate/velero-restic-restore-helper:${tag}


### PR DESCRIPTION
Not entirely sure what the `velero-restic-restore-helper` image does, but seems to be in ocpmigrate now so thinking we should include it in our "snapshots".