### PR TITLE
Set default ui config ns to "openshift-migration" to avoid UI error on 3.x

### DIFF
--- a/controller-3.yml
+++ b/controller-3.yml
@@ -8,5 +8,8 @@ spec:
   migration_velero: true
   migration_controller: false
   migration_ui: false
+
+  mig_ui_config_namespace: openshift-migration
+
   #To install the controller on Openshift 3 you will need to configure the API endpoint:
   #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443/api


### PR DESCRIPTION
Allows us to avoid cryptic Javascript error message while creating saSecret for a MigCluster from mig-ui on 3.x where there is no `openshift-config` namespace by default.