### PR TITLE
Fix operator rolebindings for k8s

### DIFF
--- a/operator.yml
+++ b/operator.yml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: "openshift-migration"
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   annotations:
@@ -17,6 +17,8 @@ metadata:
   name: system:deployers
   namespace: openshift-migration
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: system:deployer
 subjects:
 - kind: ServiceAccount
@@ -25,7 +27,7 @@ subjects:
 userNames:
 - system:serviceaccount:openshift-migration:deployer
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   annotations:
@@ -34,6 +36,8 @@ metadata:
   name: system:image-builders
   namespace: openshift-migration
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: system:image-builder
 subjects:
 - kind: ServiceAccount
@@ -42,7 +46,7 @@ subjects:
 userNames:
 - system:serviceaccount:openshift-migration:builder
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 groupNames:
 - system:serviceaccounts:openshift-migration
 kind: RoleBinding
@@ -54,9 +58,11 @@ metadata:
   name: system:image-pullers
   namespace: openshift-migration
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: system:image-puller
 subjects:
-- kind: SystemGroup
+- kind: Group
   name: system:serviceaccounts:openshift-migration
 ---
 apiVersion: v1


### PR DESCRIPTION
oc create seems to be more tolerant for these bindings on OCP3 and OCP4, the k8s ansible module fails to process properly the manifest and fails. I based the changes on OCP 3.7 once the operator manifest was applied with "oc create -f" and this makes k8s ansible module also happy. 

Now they also seem consistent as the existing rolebindings around here : https://github.com/fusor/mig-operator/blob/master/operator.yml#L138

**4.2 :** 
```
fbladilo@fbladilo:~/git-projects/mig-ci] (master %=)$ oc create -f mig-operator/operator.yml 
namespace "openshift-migration" created
rolebinding.rbac.authorization.k8s.io "system:deployers" created
serviceaccount "migration-operator" created
customresourcedefinition.apiextensions.k8s.io "migrationcontrollers.migration.openshift.io" created
role.rbac.authorization.k8s.io "migration-operator" created
rolebinding.rbac.authorization.k8s.io "migration-operator" created
clusterrolebinding.rbac.authorization.k8s.io "migration-operator" created
deployment.apps "migration-operator" created
Error from server (AlreadyExists): error when creating "mig-operator/operator.yml": rolebindings.rbac.authorization.k8s.io "system:image-builders" already exists
Error from server (AlreadyExists): error when creating "mig-operator/operator.yml": rolebindings.rbac.authorization.k8s.io "system:image-pullers" already exists

[fbladilo@fbladilo:~/git-projects/mig-ci] (master %=)$ oc describe rolebinding.rbac -n openshift-migration
Name:         migration-operator
Labels:       <none>
Annotations:  <none>
Role:
  Kind:  Role
  Name:  migration-operator
Subjects:
  Kind            Name                Namespace
  ----            ----                ---------
  ServiceAccount  migration-operator  


Name:         system:deployers
Labels:       <none>
Annotations:  openshift.io/description=Allows deploymentconfigs in this namespace to rollout pods in this namespace.  It is auto-managed by a controller; remove subjects to disable.
Role:
  Kind:  ClusterRole
  Name:  system:deployer
Subjects:
  Kind            Name      Namespace
  ----            ----      ---------
  ServiceAccount  deployer  openshift-migration


Name:         system:image-builders
Labels:       <none>
Annotations:  openshift.io/description=Allows builds in this namespace to push images to this namespace.  It is auto-managed by a controller; remove subjects to disable.
Role:
  Kind:  ClusterRole
  Name:  system:image-builder
Subjects:
  Kind            Name     Namespace
  ----            ----     ---------
  ServiceAccount  builder  openshift-migration


Name:         system:image-pullers
Labels:       <none>
Annotations:  openshift.io/description=Allows all pods in this namespace to pull images from this namespace.  It is auto-managed by a controller; remove subjects to disable.
Role:
  Kind:  ClusterRole
  Name:  system:image-puller
Subjects:
  Kind   Name                                        Namespace
  ----   ----                                        ---------
  Group  system:serviceaccounts:openshift-migration  
```

**OCP 3.7 :**
```
[fbladilo@fbladilo:~/git-projects/mig-ci] (master %=)$ oc create -f mig-operator/operator.yml 
namespace "openshift-migration" created
rolebinding.rbac.authorization.k8s.io "system:deployers" created
rolebinding.rbac.authorization.k8s.io "system:image-builders" created
rolebinding.rbac.authorization.k8s.io "system:image-pullers" created
serviceaccount "migration-operator" created
customresourcedefinition.apiextensions.k8s.io "migrationcontrollers.migration.openshift.io" created
role.rbac.authorization.k8s.io "migration-operator" created
rolebinding.rbac.authorization.k8s.io "migration-operator" created
clusterrolebinding.rbac.authorization.k8s.io "migration-operator" created
deployment.apps "migration-operator" created
```