### PR TITLE
Pin image tags to release-1.0

### DIFF
--- a/deploy/olm-catalog/mig-operator/0.0.1/mig-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/0.0.1/mig-operator.v0.0.1.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     capabilities: Seamless Upgrades
     description: Facilitates migration of workloads from Openshift 3.x to Openshift 4.x
     categories: 'OpenShift Optional'
-    containerImage: quay.io/ocpmigrate/mig-operator:stable
+    containerImage: quay.io/ocpmigrate/mig-operator:release-1.0
     createdAt: 2019-07-25T10:21:00Z
     repository: https://github.com/fusor/mig-operator
     alm-examples: '[{"apiVersion":"migration.openshift.io/v1alpha1","kind":"MigrationController","metadata":{"name":"migration-controller","namespace":"openshift-migration"},"spec":{"cluster_name":"host","migration_velero":true,"migration_controller":true,"migration_ui":true,"olm_managed":true}},{"apiVersion":"velero.io/v1","kind":"Backup","metadata":{"name":"backup","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"BackupStorageLocation","metadata":{"name":"backupstoragelocation","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"DeleteBackupRequest","metadata":{"name":"deletebackuprequest","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"DownloadRequest","metadata":{"name":"downloadrequest","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"PodVolumeBackup","metadata":{"name":"podvolumebackup","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"PodVolumeRestore","metadata":{"name":"podvolumerestore","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"ResticRepository","metadata":{"name":"resticrepository","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"Restore","metadata":{"name":"restore","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"Schedule","metadata":{"name":"schedule","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"ServerStatusRequest","metadata":{"name":"serverstatusrequest","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"velero.io/v1","kind":"VolumeSnapshotLocation","metadata":{"name":"volumesnapshotlocation","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"migration.openshift.io/v1alpha1","kind":"MigCluster","metadata":{"name":"host","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"migration.openshift.io/v1alpha1","kind":"MigPlan","metadata":{"name":"migplan","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"migration.openshift.io/v1alpha1","kind":"MigMigration","metadata":{"name":"migmigration","namespace":"openshift-migration"},"spec":{}},{"apiVersion":"migration.openshift.io/v1alpha1","kind":"MigStorage","metadata":{"name":"migstorage","namespace":"openshift-migration"},"spec":{}}]'
@@ -480,7 +480,7 @@ spec:
               serviceAccount: migration-operator
               containers:
               - name: ansible
-                image: quay.io/ocpmigrate/mig-operator:stable
+                image: quay.io/ocpmigrate/mig-operator:release-1.0
                 command:
                 - /usr/local/bin/ao-logs
                 - /tmp/ansible-operator/runner
@@ -491,7 +491,7 @@ spec:
                   name: runner
                   readOnly: true
               - name: operator
-                image: quay.io/ocpmigrate/mig-operator:stable
+                image: quay.io/ocpmigrate/mig-operator:release-1.0
                 imagePullPolicy: Always
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,14 +22,14 @@ spec:
         - /usr/local/bin/ao-logs
         - /tmp/ansible-operator/runner
         - stdout
-        image: quay.io/ocpmigrate/mig-operator:stable
+        image: quay.io/ocpmigrate/mig-operator:release-1.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: quay.io/ocpmigrate/mig-operator:stable
+        image: quay.io/ocpmigrate/mig-operator:release-1.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner

--- a/operator.yml
+++ b/operator.yml
@@ -193,14 +193,14 @@ spec:
         - /usr/local/bin/ao-logs
         - /tmp/ansible-operator/runner
         - stdout
-        image: quay.io/ocpmigrate/mig-operator:stable
+        image: quay.io/ocpmigrate/mig-operator:release-1.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: quay.io/ocpmigrate/mig-operator:stable
+        image: quay.io/ocpmigrate/mig-operator:release-1.0
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -7,7 +7,7 @@ mig_controller_limits_cpu: "100m"
 mig_controller_limits_memory: "800Mi"
 mig_controller_requests_cpu: "100m"
 mig_controller_requests_memory: "350Mi"
-mig_controller_version: "{{ snapshot_tag | default('stable') }}"
+mig_controller_version: "{{ snapshot_tag | default('release-1.0') }}"
 mig_namespace: openshift-migration
 mig_svc_account: true
 mig_ui_cluster_api_endpoint: ""
@@ -18,12 +18,12 @@ mig_ui_image: quay.io/ocpmigrate/mig-ui
 mig_ui_oauth_user_scope: "user:full"
 mig_ui_oauth_redirect_url: ""
 mig_ui_oauth_secret: ""
-mig_ui_version: "{{ snapshot_tag | default('stable') }}"
+mig_ui_version: "{{ snapshot_tag | default('release-1.0') }}"
 olm_managed: false
 restic_pv_host_path: /var/lib/kubelet/pods
 ui_state: absent
 velero_aws_secret_name: cloud-credentials
-velero_image: "quay.io/ocpmigrate/velero:{{ snapshot_tag | default('stable') }}"
-velero_plugin_image: "quay.io/ocpmigrate/migration-plugin:{{ snapshot_tag | default('stable') }}"
-velero_restic_restore_helper_image: "quay.io/ocpmigrate/velero-restic-restore-helper:{{ snapshot_tag | default('stable') }}"
+velero_image: "quay.io/ocpmigrate/velero:{{ snapshot_tag | default('fusor-1.1') }}"
+velero_plugin_image: "quay.io/ocpmigrate/migration-plugin:{{ snapshot_tag | default('release-1.0') }}"
+velero_restic_restore_helper_image: "quay.io/ocpmigrate/velero-restic-restore-helper:{{ snapshot_tag | default('fusor-1.1') }}"
 velero_state: absent


### PR DESCRIPTION
One exception is the velero_image and the restic restore helper, both of
which must use the fusor-1.1 tags.