### PR TITLE
Remove '/api' from sample OpenShift 3 API endpoint

### DIFF
--- a/controller-3.yml
+++ b/controller-3.yml
@@ -12,4 +12,4 @@ spec:
   mig_ui_config_namespace: openshift-migration
 
   #To install the controller on Openshift 3 you will need to configure the API endpoint:
-  #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443/api
+  #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443


### PR DESCRIPTION
I believe it was a typo to include `/api` on the sample endpoint. This has not worked for me.

@jmontleon 