### PR TITLE
Fix 1.0 maturity value

### DIFF
--- a/deploy/olm-catalog/mig-operator/v1.0.0/mig-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/v1.0.0/mig-operator.v1.0.0.clusterserviceversion.yaml
@@ -534,7 +534,7 @@ spec:
               volumes:
               - name: runner
                 emptyDir: {}
-  maturity: release
+  maturity: stable
   version: 1.0.0
   customresourcedefinitions:
     owned:


### PR DESCRIPTION
According to OLM maturity has to be set to a set of specific values.

`spec.maturity in body should be one of [planning pre-alpha alpha beta stable mature inactive deprecated]`