### PR TITLE
Fetch kubeapiserver for 4.1 CORS configuration

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -240,6 +240,13 @@
           state: present
           definition: "{{ lookup('file', '/tmp/apiserver.yaml') | from_yaml }}"
 
+    - name: Retrieve kubeapiserver operator definition
+      k8s_facts:
+        api_version: "operator.openshift.io/v1"
+        kind: "kubeapiserver"
+        name: "cluster"
+      register: kubeapiserver
+
     - when: deprecated_cors_configuration and (
             kubeapiserver.resources[0].spec.unsupportedConfigOverrides is not defined or
             kubeapiserver.resources[0].spec.unsupportedConfigOverrides.corsAllowedOrigins is not defined or


### PR DESCRIPTION
Between the 4.2 CORS changes and fix for the kubeapiserver operator to apiserver config we lost the kubeapiserver fetch for 4.1 CORS configuration.