### PR TITLE
Fix target namespace creation in test helper mirror images script

### DIFF
--- a/deploy/test-helpers/mirror_downstream_mig_images.sh
+++ b/deploy/test-helpers/mirror_downstream_mig_images.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-oc create namespace $TARGET_NAMESPACE > /dev/null 2>&1 ||:
-oc create namespace openshift-migration > /dev/null 2>&1 ||:
-oc policy add-role-to-group system:image-puller system:serviceaccounts:openshift-migration --namespace=$TARGET_NAMESPACE
-
 _dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $_dir/my_var
 
@@ -13,6 +9,11 @@ echo "Downstream registry: $DOWNSTREAM_REGISTRY"
 echo "Target cluster registry: $CLUSTER_REGISTRY_ROUTE"
 echo "Downstream repo name: $DOWNSTREAM_REPONAME"
 echo "Target repo name: $TARGET_NAMESPACE"
+
+echo "Creating namespaces:"
+oc create namespace $TARGET_NAMESPACE > /dev/null 2>&1 ||:
+oc create namespace openshift-migration > /dev/null 2>&1 ||:
+oc policy add-role-to-group system:image-puller system:serviceaccounts:openshift-migration --namespace=$TARGET_NAMESPACE
 
 echo "Pulling images from:"
 for img in "${IMAGES[@]}"; do


### PR DESCRIPTION
Move the instructions to create the namespaces after the source command, so that the variables are available when these instructions are executed.