### PR TITLE
migstorage CRD change for snapshot timeout

### DIFF
--- a/deploy/olm-catalog/mig-operator/latest/migstorage.crd.yaml
+++ b/deploy/olm-catalog/mig-operator/latest/migstorage.crd.yaml
@@ -64,14 +64,14 @@ spec:
               properties:
                 awsRegion:
                   type: string
-                awsSnapshotCreationTimeout:
-                  type: string
                 azureApiTimeout:
                   type: string
                 azureResourceGroup:
                   type: string
                 credsSecretRef:
                   type: object
+                snapshotCreationTimeout:
+                  type: string
               type: object
             volumeSnapshotProvider:
               type: string

--- a/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
@@ -64,14 +64,14 @@ spec:
               properties:
                 awsRegion:
                   type: string
-                awsSnapshotCreationTimeout:
-                  type: string
                 azureApiTimeout:
                   type: string
                 azureResourceGroup:
                   type: string
                 credsSecretRef:
                   type: object
+                snapshotCreationTimeout:
+                  type: string
               type: object
             volumeSnapshotProvider:
               type: string


### PR DESCRIPTION
The related changes are targeted for 1.0.1 but not (yet) on the release branch.