### PR TITLE
add snapshotCreationTimeout to 1.0.1 migstorage crd

### DIFF
--- a/deploy/olm-catalog/mig-operator/v1.0.1/migstorage.crd.yaml
+++ b/deploy/olm-catalog/mig-operator/v1.0.1/migstorage.crd.yaml
@@ -70,6 +70,8 @@ spec:
                   type: string
                 credsSecretRef:
                   type: object
+                snapshotCreationTimeout:
+                  type: string
               type: object
             volumeSnapshotProvider:
               type: string


### PR DESCRIPTION
This will be needed once the snapshot timeout changes are merged to release-1.0 for the controller.