### PR TITLE
Add separate cred secrets for azure/gcp

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -33,6 +33,8 @@ restic_pv_host_path: /var/lib/kubelet/pods
 restic_timeout: 1h
 ui_state: absent
 velero_aws_secret_name: cloud-credentials
+velero_gcp_secret_name: gcp-cloud-credentials
+velero_azure_secret_name: azure-cloud-credentials
 velero_debug: false
 velero_image: "{{ registry }}/{{ project }}/{{ velero_repo }}"
 velero_repo: "{{ lookup( 'env', 'VELERO_REPO') }}"

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -92,6 +92,22 @@
         namespace: "{{ mig_namespace }}"
       register: secret_status
 
+    - name: Check if gcp-cloud-credentials secret exists already so we don't update it
+      k8s_facts:
+        api_version: v1
+        kind: Secret
+        name: "{{ velero_gcp_secret_name }}"
+        namespace: "{{ mig_namespace }}"
+      register: gcp_secret_status
+
+    - name: Check if azure-cloud-credentials secret exists already so we don't update it
+      k8s_facts:
+        api_version: v1
+        kind: Secret
+        name: "{{ velero_azure_secret_name }}"
+        namespace: "{{ mig_namespace }}"
+      register: azure_secret_status
+
     - name: "Create empty velero S3 secret"
       k8s:
         state: "{{ velero_state }}"
@@ -104,6 +120,32 @@
           data:
             cloud: ""
       when: (secret_status.resources|length) == 0
+
+    - name: "Create empty velero gcp secret"
+      k8s:
+        state: "{{ velero_state }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ velero_gcp_secret_name }}"
+            namespace: "{{ mig_namespace }}"
+          data:
+            cloud: ""
+      when: (gcp_secret_status.resources|length) == 0
+
+    - name: "Create empty velero azure secret"
+      k8s:
+        state: "{{ velero_state }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ velero_azure_secret_name }}"
+            namespace: "{{ mig_namespace }}"
+          data:
+            cloud: ""
+      when: (azure_secret_status.resources|length) == 0
 
     - name: "Set up velero supporting resources (CRDS, SA, SCC) when not managed by OLM"
       k8s:

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -48,6 +48,10 @@ spec:
           volumeMounts:
             - name: {{ velero_aws_secret_name }}
               mountPath: /credentials
+            - name: {{ velero_gcp_secret_name }}
+              mountPath: /credentials-gcp
+            - name: {{ velero_azure_secret_name }}
+              mountPath: /credentials-azure
             - name: plugins
               mountPath: /plugins
             - name: scratch
@@ -56,9 +60,9 @@ spec:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /credentials/cloud
+              value: /credentials-gcp/cloud
             - name: AZURE_CREDENTIALS_FILE
-              value: /credentials/cloud
+              value: /credentials-azure/cloud
             - name: VELERO_NAMESPACE
               value: {{ mig_namespace }}
             - name: VELERO_SCRATCH_DIR
@@ -67,6 +71,12 @@ spec:
         - name: {{ velero_aws_secret_name }}
           secret:
             secretName: {{ velero_aws_secret_name }}
+        - name: {{ velero_gcp_secret_name }}
+          secret:
+            secretName: {{ velero_gcp_secret_name }}
+        - name: {{ velero_azure_secret_name }}
+          secret:
+            secretName: {{ velero_azure_secret_name }}
         - name: plugins
           emptyDir: {}
         - name: scratch
@@ -103,6 +113,12 @@ spec:
         - name: {{ velero_aws_secret_name }}
           secret:
             secretName: {{ velero_aws_secret_name }}
+        - name: {{ velero_gcp_secret_name }}
+          secret:
+            secretName: {{ velero_gcp_secret_name }}
+        - name: {{ velero_azure_secret_name }}
+          secret:
+            secretName: {{ velero_azure_secret_name }}
         - name: host-pods
           hostPath:
             path: {{ restic_pv_host_path }}
@@ -122,6 +138,10 @@ spec:
           volumeMounts:
             - name: {{ velero_aws_secret_name }}
               mountPath: /credentials
+            - name: {{ velero_gcp_secret_name }}
+              mountPath: /credentials-gcp
+            - name: {{ velero_azure_secret_name }}
+              mountPath: /credentials-azure
             - name: host-pods
               mountPath: /host_pods
               mountPropagation: HostToContainer
@@ -139,9 +159,9 @@ spec:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /credentials/cloud
+              value: /credentials-gcp/cloud
             - name: AZURE_CREDENTIALS_FILE
-              value: /credentials/cloud
+              value: /credentials-azure/cloud
             - name: VELERO_SCRATCH_DIR
               value: /scratch
 


### PR DESCRIPTION
Create separate cred secrets for aws, azure, and gcp, mount them separately and configure velero/restic to look in the separate locations.