### PR TITLE
Use oc image mirror to mirror images

### DIFF
--- a/deploy/test-helpers/mirror_downstream_mig_images.sh
+++ b/deploy/test-helpers/mirror_downstream_mig_images.sh
@@ -2,7 +2,7 @@
 _dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $_dir/my_var
 
-DOCKERCMD=${DOCKERCMD:-docker}
+OCCMD=${DOCKERCMD:-oc}
 
 echo "Mirroring downstream images..."
 echo "Downstream registry: $DOWNSTREAM_REGISTRY"
@@ -15,21 +15,19 @@ oc create namespace $TARGET_NAMESPACE > /dev/null 2>&1 ||:
 oc create namespace openshift-migration > /dev/null 2>&1 ||:
 oc policy add-role-to-group system:image-puller system:serviceaccounts:openshift-migration --namespace=$TARGET_NAMESPACE
 
+function fullImgSrc() { echo "$DOWNSTREAM_REGISTRY/$DOWNSTREAM_ORG/$DOWNSTREAM_REPO_PREFIX${IMG_MAP[${img}_repo]}:${IMG_MAP[${img}_ds_tag]}"; }
+function fullImgDest() { echo "$CLUSTER_REGISTRY_ROUTE/$TARGET_NAMESPACE/${IMG_MAP[${img}_tgt_name]}:${IMG_MAP[${img}_tgt_tag]}"; }
+
 echo "Pulling images from:"
 for img in "${IMAGES[@]}"; do
-  echo "-> $DOWNSTREAM_REGISTRY/$DOWNSTREAM_ORG/$DOWNSTREAM_REPO_PREFIX${IMG_MAP[${img}_repo]}:${IMG_MAP[${img}_ds_tag]}"
+  echo "-> $(fullImgSrc)"
 done
 
 echo "Pushing images to:"
 for img in "${IMAGES[@]}"; do
-  echo "-> $CLUSTER_REGISTRY_ROUTE/$TARGET_NAMESPACE/${IMG_MAP[${img}_tgt_name]}:${IMG_MAP[${img}_tgt_tag]}"
+  echo "-> $(fullImgDest)"
 done
 
 for img in "${IMAGES[@]}"; do
-  fullImgSrc="$DOWNSTREAM_REGISTRY/$DOWNSTREAM_ORG/$DOWNSTREAM_REPO_PREFIX${IMG_MAP[${img}_repo]}:${IMG_MAP[${img}_ds_tag]}"
-  fullImgDest="$CLUSTER_REGISTRY_ROUTE/$TARGET_NAMESPACE/${IMG_MAP[${img}_tgt_name]}:${IMG_MAP[${img}_tgt_tag]}"
-
-  $DOCKERCMD pull $fullImgSrc
-  $DOCKERCMD tag $fullImgSrc $fullImgDest
-  $DOCKERCMD push $fullImgDest
+  $OCCMD image mirror --insecure=true $(fullImgSrc)=$(fullImgDest)
 done


### PR DESCRIPTION
Improvements:
 - Use functions so strings can be updated in just one place
 - Use `oc image mirror` which streams images from registry to registry. No need to store locally
 - Don't need to worry about whether podman was aliased to docker, etc. since `podman push` is bad
 - Use `--insecure=true` so insecure registries doesn't need to be updated anywhere