### PR TITLE
Change usage docs to reference release 1.0

### DIFF
--- a/docs/usage/1.md
+++ b/docs/usage/1.md
@@ -33,12 +33,12 @@ For migrations in disconnected environments it may be desired to pull required i
 
 _Required Images - CAM Tool_
 ```
-quay.io/ocpmigrate/mig-controller:htb3
-quay.io/ocpmigrate/mig-operator:htb3
-quay.io/ocpmigrate/mig-ui:htb3
-quay.io/ocpmigrate/velero:htb3
-quay.io/ocpmigrate/migration-plugin:htb3
-quay.io/ocpmigrate/velero-restic-restore-helper:htb3
+quay.io/ocpmigrate/mig-controller:release-1.0
+quay.io/ocpmigrate/mig-operator:release-1.0
+quay.io/ocpmigrate/mig-ui:release-1.0
+quay.io/ocpmigrate/velero:stable
+quay.io/ocpmigrate/migration-plugin:release-1.0
+quay.io/ocpmigrate/velero-restic-restore-helper:stable
 registry.access.redhat.com/rhel7
 docker.io/registry:2
 ```
@@ -57,12 +57,12 @@ docker.io/centos/mongodb-36-centos7
 
 On both the _source_ and the _destination_ cluster, we'll use mig-operator to install components needed to perform a migration. 
 
-A manifest for deploying mig-operator to OpenShift 3.x and 4.x has been made available as [operator.yml](https://raw.githubusercontent.com/fusor/mig-operator/htb3/operator.yml)
+A manifest for deploying mig-operator to OpenShift 3.x and 4.x has been made available as [operator.yml](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/operator.yml)
 
 
 ```
 # The operator manifest should be downloaded and edited to the specifications above.
-# https://raw.githubusercontent.com/fusor/mig-operator/htb3/operator.yml
+# https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/operator.yml
 
 --------------------------------------------------------------------------------------
 
@@ -87,7 +87,7 @@ Next up, we'll tell mig-operator which components it should install for us by cr
 
 When you install mig-operator, it introduces a `MigrationController` CRD to your cluster.
 
-The sample [`controller-3.yml`](https://raw.githubusercontent.com/fusor/mig-operator/htb3/controller-3.yml) and [`controller-4.yml`](https://raw.githubusercontent.com/fusor/mig-operator/htb3/controller-4.yml) are provided with recommended defaults for:
+The sample [`controller-3.yml`](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-3.yml) and [`controller-4.yml`](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-4.yml) are provided with recommended defaults for:
 - Using OpenShift 3.x as the source cluster (_only_ Velero installed)
 - Using OpenShift 4.x as the destination _cluster_ (_all_ components: Velero, mig-controller, and mig-ui installed)
 
@@ -96,13 +96,13 @@ If you wish to run app migrations with a different configuration, it's as simple
 ### OpenShift 3.x 
 For each OpenShift 3.x cluster that will be involved in the migration, use controller-3.yml as a starting point.
 
-https://raw.githubusercontent.com/fusor/mig-operator/htb3/controller-3.yml
+https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-3.yml
 
 
 ### OpenShift 4.x
 For each OpenShift 4.x cluster that will be involved in the migration, use  controller-4.yml as a starting point
 
-https://raw.githubusercontent.com/fusor/mig-operator/htb3/controller-4.yml
+https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-4.yml
 
 ## 1.3.1 Configuring the MigrationController spec
 
@@ -113,8 +113,8 @@ apiVersion: migration.openshift.io/v1alpha1
 kind: MigrationController
 spec:
   [...]
-  # 'snapshot_tag' should be htb3 to follow along with this guide
-  snapshot_tag: htb3
+  # 'snapshot_tag' should be release-1.0 to follow along with this guide
+  snapshot_tag: release-1.0
 
 
   # 'migration_velero' should always be 'true'
@@ -133,7 +133,7 @@ spec:
 Sample _source cluster_ MigrationController config:
 ```
   [...]
-  snapshot_tag: htb3
+  snapshot_tag: release-1.0
 
   migration_velero: true 
   migration_controller: false
@@ -144,7 +144,7 @@ Sample _source cluster_ MigrationController config:
 Sample _destination cluster_ MigrationController config
 ```
   [...]
-  snapshot_tag: htb3
+  snapshot_tag: release-1.0
 
   migration_velero: true 
   migration_controller: true

--- a/docs/usage/1.md
+++ b/docs/usage/1.md
@@ -57,12 +57,12 @@ docker.io/centos/mongodb-36-centos7
 
 On both the _source_ and the _destination_ cluster, we'll use mig-operator to install components needed to perform a migration. 
 
-A manifest for deploying mig-operator to OpenShift 3.x and 4.x has been made available as [operator.yml](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/operator.yml)
+A manifest for deploying mig-operator to OpenShift 3.x and 4.x has been made available as [operator.yml](https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/operator.yml)
 
 
 ```
 # The operator manifest should be downloaded and edited to the specifications above.
-# https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/operator.yml
+# https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/operator.yml
 
 --------------------------------------------------------------------------------------
 
@@ -87,7 +87,7 @@ Next up, we'll tell mig-operator which components it should install for us by cr
 
 When you install mig-operator, it introduces a `MigrationController` CRD to your cluster.
 
-The sample [`controller-3.yml`](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-3.yml) and [`controller-4.yml`](https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-4.yml) are provided with recommended defaults for:
+The sample [`controller-3.yml`](https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/controller-3.yml) and [`controller-4.yml`](https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/controller-4.yml) are provided with recommended defaults for:
 - Using OpenShift 3.x as the source cluster (_only_ Velero installed)
 - Using OpenShift 4.x as the destination _cluster_ (_all_ components: Velero, mig-controller, and mig-ui installed)
 
@@ -96,13 +96,13 @@ If you wish to run app migrations with a different configuration, it's as simple
 ### OpenShift 3.x 
 For each OpenShift 3.x cluster that will be involved in the migration, use controller-3.yml as a starting point.
 
-https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-3.yml
+https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/controller-3.yml
 
 
 ### OpenShift 4.x
 For each OpenShift 4.x cluster that will be involved in the migration, use  controller-4.yml as a starting point
 
-https://raw.githubusercontent.com/fusor/mig-operator/release-1.0/controller-4.yml
+https://raw.githubusercontent.com/fusor/mig-operator/master/deploy/non-olm/v1.0.0/controller-4.yml
 
 ## 1.3.1 Configuring the MigrationController spec
 

--- a/docs/usage/1.md
+++ b/docs/usage/1.md
@@ -36,9 +36,9 @@ _Required Images - CAM Tool_
 quay.io/ocpmigrate/mig-controller:release-1.0
 quay.io/ocpmigrate/mig-operator:release-1.0
 quay.io/ocpmigrate/mig-ui:release-1.0
-quay.io/ocpmigrate/velero:stable
+quay.io/ocpmigrate/velero:fusor-1.1
 quay.io/ocpmigrate/migration-plugin:release-1.0
-quay.io/ocpmigrate/velero-restic-restore-helper:stable
+quay.io/ocpmigrate/velero-restic-restore-helper:fusor-1.1
 registry.access.redhat.com/rhel7
 docker.io/registry:2
 ```


### PR DESCRIPTION
I'm fairly certain that `quay.io/ocpmigrate/velero:stable` and `quay.io/ocpmigrate/velero-restic-restore-helper:stable` are incorrect, but I don't know what the correct image to reference for these is. 

It kind of looks like we never tagged release-1.0 images for these in quay.