### PR TITLE
CORS configuration for OCP4.1 and OCP4.2 should never be able to simultaneously configured

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -17,7 +17,7 @@ mig_namespace: openshift-migration
 mig_svc_account: true
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""
-mig_ui_configmap_name : mig-ui-config
+mig_ui_configmap_name: mig-ui-config
 mig_ui_config_namespace: openshift-migration
 mig_ui_image: "{{ registry }}/{{ project }}/{{ mig_ui_repo }}"
 mig_ui_oauth_user_scope: "user:full"

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -9,11 +9,14 @@
         state: "present"
         definition: "{{ lookup('template', 'migration-controller.yml.j2') }}"
 
-    - k8s_status:
+    - name: Clean conditions and set Reconciling state
+      k8s_status:
         api_version: migration.openshift.io/v1alpha1
         kind: MigrationController
         name: "{{ meta.name }}"
         namespace: "{{ meta.namespace }}"
+        force: true
+        conditions: []
         status:
           phase: Reconciling
 
@@ -242,8 +245,9 @@
           name: "cluster"
         register: apiserver
 
-      - when: apiserver.resources[0].spec.additionalCORSAllowedOrigins is not defined or
-              mig_ui_cors_url not in apiserver.resources[0].spec.additionalCORSAllowedOrigins
+      - when: not(deprecated_cors_configuration) and (
+              apiserver.resources[0].spec.additionalCORSAllowedOrigins is not defined or
+              mig_ui_cors_url not in apiserver.resources[0].spec.additionalCORSAllowedOrigins)
         block:
         - name: Write apiserver config definition for modification
           copy:
@@ -292,6 +296,36 @@
           k8s:
             state: present
             definition: "{{ lookup('file', '/tmp/kubeapiserver.yaml') | from_yaml }}"
+
+      - name: Assert kubeapiserver setup matches the deprecated_cors_configuration setting
+        k8s_status:
+          api_version: migration.openshift.io/v1alpha1
+          kind: MigrationController
+          name: "{{ meta.name }}"
+          namespace: "{{ meta.namespace }}"
+          conditions:
+            - type: Critical
+              status: True
+              reason: "DepricatedCorsMisConfigured"
+              message: "Unexpected CORS configuration for apiserver"
+        when: deprecated_cors_configuration and
+              apiserver.resources[0].spec.additionalCORSAllowedOrigins is defined and
+              mig_ui_cors_url in apiserver.resources[0].spec.additionalCORSAllowedOrigins
+
+      - name: Assert apiserver setup matches the deprecated_cors_configuration setting
+        k8s_status:
+          api_version: migration.openshift.io/v1alpha1
+          kind: MigrationController
+          name: "{{ meta.name }}"
+          namespace: "{{ meta.namespace }}"
+          conditions:
+            - type: Critical
+              status: True
+              reason: "CorsMisConfigured"
+              message: "Unexpected CORS configuration for kubeapiserver"
+        when: not(deprecated_cors_configuration) and
+              kubeapiserver.resources[0].spec.unsupportedConfigOverrides.corsAllowedOrigins is defined and
+              mig_ui_cors_url in kubeapiserver.resources[0].spec.unsupportedConfigOverrides.corsAllowedOrigins
 
       - name: Retrieve authentication operator definition
         k8s_facts:
@@ -483,7 +517,7 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Reconciled
-    when: olm_managed and reconciled
+    when: reconciled
 
   - k8s_status:
       api_version: migration.openshift.io/v1alpha1
@@ -492,5 +526,26 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Failed
-    when: olm_managed and not(reconciled)
+    when: not(reconciled)
+
+  - name: Retrieve migrationController status
+    k8s_facts:
+      api_version: migration.openshift.io/v1alpha1
+      kind: MigrationController
+      namespace: "{{ mig_namespace }}"
+    register: controller
+
+  - when: controller.resources is defined and
+          controller.resources[0].status.conditions is defined
+    block:
+    - k8s_status:
+        api_version: migration.openshift.io/v1alpha1
+        kind: MigrationController
+        name: "{{ meta.name }}"
+        namespace: "{{ meta.namespace }}"
+        status:
+          phase: Failed
+      when: item.type == 'Critical'
+      with_items: "{{ controller.resources[0].status.conditions }}"
+
 

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -245,7 +245,7 @@
           name: "cluster"
         register: apiserver
 
-      - when: not(deprecated_cors_configuration) and (
+      - when: not deprecated_cors_configuration and (
               apiserver.resources[0].spec.additionalCORSAllowedOrigins is not defined or
               mig_ui_cors_url not in apiserver.resources[0].spec.additionalCORSAllowedOrigins)
         block:
@@ -308,7 +308,8 @@
               status: True
               reason: "DepricatedCorsMisConfigured"
               message: "Unexpected CORS configuration for apiserver"
-        when: deprecated_cors_configuration and
+        when: olm_managed and
+              deprecated_cors_configuration and
               apiserver.resources[0].spec.additionalCORSAllowedOrigins is defined and
               mig_ui_cors_url in apiserver.resources[0].spec.additionalCORSAllowedOrigins
 
@@ -323,7 +324,8 @@
               status: True
               reason: "CorsMisConfigured"
               message: "Unexpected CORS configuration for kubeapiserver"
-        when: not(deprecated_cors_configuration) and
+        when: olm_managed and
+              not deprecated_cors_configuration and
               kubeapiserver.resources[0].spec.unsupportedConfigOverrides.corsAllowedOrigins is defined and
               mig_ui_cors_url in kubeapiserver.resources[0].spec.unsupportedConfigOverrides.corsAllowedOrigins
 
@@ -436,7 +438,7 @@
       state: "present"
       definition: "{{ lookup('template', 'mig_host_cluster.yml.j2') }}"
 
-  - when: not(migration_controller)
+  - when: not migration_controller
     block:
     - name: Find Controller ReplicaSets
       k8s_facts:
@@ -454,7 +456,7 @@
         namespace: "{{ mig_namespace }}"
       with_items: "{{ controller_replicasets.resources }}"
 
-  - when: not(migration_ui)
+  - when: not migration_ui
     block:
     - name: Find UI ReplicaSets
       k8s_facts:
@@ -472,7 +474,7 @@
         namespace: "{{ mig_namespace }}"
       with_items: "{{ ui_replicasets.resources }}"
 
-  - when: not(migration_velero)
+  - when: not migration_velero
     block:
     - name: Find Velero ReplicaSets
       k8s_facts:
@@ -517,7 +519,7 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Reconciled
-    when: reconciled
+    when: olm_managed and reconciled
 
   - k8s_status:
       api_version: migration.openshift.io/v1alpha1
@@ -526,7 +528,7 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Failed
-    when: not(reconciled)
+    when: olm_managed and not reconciled
 
   - name: Retrieve migrationController status
     k8s_facts:
@@ -535,7 +537,8 @@
       namespace: "{{ mig_namespace }}"
     register: controller
 
-  - when: controller.resources is defined and
+  - when: olm_managed and
+          controller.resources is defined and
           controller.resources[0].status.conditions is defined
     block:
     - k8s_status:


### PR DESCRIPTION
- Asserts that CORS configuration fits for selected cluster version
- Manages conditions on controller CR