### PR TITLE
Add handler to restart velero and restic on a config change

### DIFF
--- a/roles/migrationcontroller/handlers/main.yml
+++ b/roles/migrationcontroller/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
-# handlers file for migration
+- name: restart velero
+  include: restart_velero.yml
+
+- name: restart restic
+  include: restart_restic.yml

--- a/roles/migrationcontroller/handlers/restart_restic.yml
+++ b/roles/migrationcontroller/handlers/restart_restic.yml
@@ -1,0 +1,15 @@
+- name: Find Restic Pods
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ mig_namespace }}"
+    label_selectors:
+    - name=restic
+  register: restic_pods
+
+- name: Terminate Restic Pods
+  k8s:
+    name: "{{ item.metadata.name }}"
+    state: absent
+    kind: Pod
+    namespace: "{{ mig_namespace }}"
+  with_items: "{{ restic_pods.resources }}"

--- a/roles/migrationcontroller/handlers/restart_velero.yml
+++ b/roles/migrationcontroller/handlers/restart_velero.yml
@@ -1,0 +1,15 @@
+- name: Find Velero Pods
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ mig_namespace }}"
+    label_selectors:
+    - component=velero
+  register: velero_pods
+
+- name: Terminate Velero Pods
+  k8s:
+    name: "{{ item.metadata.name }}"
+    state: absent
+    kind: Pod
+    namespace: "{{ mig_namespace }}"
+  with_items: "{{ velero_pods.resources }}"

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -160,6 +160,9 @@
     k8s:
       state: "{{ velero_state }}"
       definition: "{{ lookup('template', 'velero.yml.j2') }}"
+    notify:
+    - restart velero
+    - restart restic
 
   - name: migration_controller
     block:


### PR DESCRIPTION
It is not 100% clear from the comments, but I get the impression that the customer may have been attempting to update the velero-restic-restore-helper image location and were not seeing the change take effect in this bug.

https://jira.coreos.com/browse/MIG-82 / https://bugzilla.redhat.com/show_bug.cgi?id=1776490

For that to happen velero would most likely need to be restarted so this PR introduces changes to run two handlers to restart the pods when any of the velero or restic configuration/template changes.