### PR TITLE
Changes required for velero 1.2

### DIFF
--- a/deploy/non-olm/latest/operator.yml
+++ b/deploy/non-olm/latest/operator.yml
@@ -230,11 +230,23 @@ spec:
           value: migration-plugin
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
           value: velero-restic-restore-helper
+        - name: VELERO_AWS_PLUGIN_REPO
+          value: velero-plugin-for-aws
+        - name: VELERO_GCP_PLUGIN_REPO
+          value: velero-plugin-for-gcp
+        - name: VELERO_AZURE_PLUGIN_REPO
+          value: velero-plugin-for-microsoft-azure
         - name: VELERO_TAG
           value: latest
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
           value: latest
         - name: VELERO_PLUGIN_TAG
+          value: latest
+        - name: VELERO_AWS_PLUGIN_TAG
+          value: latest
+        - name: VELERO_GCP_PLUGIN_TAG
+          value: latest
+        - name: VELERO_AZURE_PLUGIN_TAG
           value: latest
         - name: MIG_UI_TAG
           value: latest

--- a/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
@@ -703,6 +703,18 @@ spec:
                   value: migration-plugin
                 - name: VELERO_PLUGIN_TAG
                   value: latest
+                - name: VELERO_AWS_PLUGIN_REPO
+                  value: velero-plugin-for-aws
+                - name: VELERO_AWS_PLUGIN_TAG
+                  value: latest
+                - name: VELERO_GCP_PLUGIN_REPO
+                  value: velero-plugin-for-gcp
+                - name: VELERO_GCP_PLUGIN_TAG
+                  value: latest
+                - name: VELERO_AZURE_PLUGIN_REPO
+                  value: velero-plugin-for-microsoft-azure
+                - name: VELERO_AZURE_PLUGIN_TAG
+                  value: latest
                 - name: VELERO_RESTIC_RESTORE_HELPER_REPO
                   value: velero-restic-restore-helper
                 - name: VELERO_RESTIC_RESTORE_HELPER_TAG

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -59,6 +59,18 @@ spec:
           value: migration-plugin
         - name: VELERO_RESTIC_RESTORE_HELPER_REPO
           value: velero-restic-restore-helper
+        - name: VELERO_AWS_PLUGIN_REPO
+          value: velero-plugin-for-aws
+        - name: VELERO_GCP_PLUGIN_REPO
+          value: velero-plugin-for-gcp
+        - name: VELERO_AZURE_PLUGIN_REPO
+          value: velero-plugin-for-microsoft-azure
+        - name: VELERO_AWS_PLUGIN_TAG
+          value: latest
+        - name: VELERO_GCP_PLUGIN_TAG
+          value: latest
+        - name: VELERO_AZURE_PLUGIN_TAG
+          value: latest
         - name: MIGRATION_TAG
           value: stable
         - name: VELERO_TAG

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -45,6 +45,15 @@ velero_plugin_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_PLUGIN_
 velero_restic_restore_helper_image: "{{ registry }}/{{ project }}/{{ velero_restic_restore_helper_repo }}"
 velero_restic_restore_helper_repo: "{{ lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_REPO') }}"
 velero_restic_restore_helper_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_TAG')) }}"
+velero_aws_plugin_image: "{{ registry }}/{{ project }}/{{ velero_aws_plugin_repo }}"
+velero_aws_plugin_repo: "{{ lookup( 'env', 'VELERO_AWS_PLUGIN_REPO') }}"
+velero_aws_plugin_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_AWS_PLUGIN_TAG')) }}"
+velero_gcp_plugin_image: "{{ registry }}/{{ project }}/{{ velero_gcp_plugin_repo }}"
+velero_gcp_plugin_repo: "{{ lookup( 'env', 'VELERO_GCP_PLUGIN_REPO') }}"
+velero_gcp_plugin_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_GCP_PLUGIN_TAG')) }}"
+velero_azure_plugin_image: "{{ registry }}/{{ project }}/{{ velero_azure_plugin_repo }}"
+velero_azure_plugin_repo: "{{ lookup( 'env', 'VELERO_AZURE_PLUGIN_REPO') }}"
+velero_azure_plugin_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_AZURE_PLUGIN_TAG')) }}"
 velero_state: absent
 
 # MCG integration

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -91,6 +91,33 @@ spec:
           volumeMounts:
           - mountPath: /target
             name: plugins
+        - image: {{ velero_aws_plugin_image }}:{{ velero_aws_plugin_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: velero-plugin-for-aws
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /target
+            name: plugins
+        - image: {{ velero_gcp_plugin_image }}:{{ velero_gcp_plugin_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: velero-plugin-for-gcp
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /target
+            name: plugins
+        - image: {{ velero_azure_plugin_image }}:{{ velero_azure_plugin_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: velero-plugin-for-microsoft-azure
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /target
+            name: plugins
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet


### PR DESCRIPTION
Added plugin configuration for aws, gcp, and azure storage plugins
required for velero 1.2

This won't be ready to merge until the velero 1.2 upgrade PR is merged (https://github.com/fusor/velero/pull/41) and there are quay builds for the three storage plugins.