### PR TITLE
Remove creation/deletion of openshift-migration namespace step

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -40,18 +40,6 @@
       mig_ui_config_namespace: openshift-config
     when: config_namespace_check.resources|length > 0
 
-  - name: "Set up namespace for mig resources"
-    k8s:
-      state: "present"
-      definition: "{{ lookup('template', 'mig_namespace.yml.j2') }}"
-    when: migration_ui or migration_controller or migration_velero
-
-  - name: "Set up mig operator namespace"
-    k8s:
-      state: "present"
-      definition: "{{ lookup('template', 'mig_namespace.yml.j2') }}"
-    when: not olm_managed and (migration_ui or migration_controller or migration_velero)
-
   #This ConfigMap contains the cluster config on Openshift 4.
   #Looking for it provides a rudimentary way to see what version we're on.
   #It also lets us generate the cluster API endpoint URL on Openshift 4.

--- a/roles/migrationcontroller/templates/mig_namespace.yml.j2
+++ b/roles/migrationcontroller/templates/mig_namespace.yml.j2
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: {{ mig_namespace }}


### PR DESCRIPTION
For metrics ingestion to work, we need to request that users label the openshift-migration namespace in a particular way that would be overwritten by mig-operator at present. 

Creation of the openshift-migration namespace from mig-operator is leftover from when we used separate namespaces for mig-operator and mig-controller, and should not change anything about the UX now.