### PR TITLE
Attempt to fix handler not found

### DIFF
--- a/roles/migrationcontroller/handlers/main.yml
+++ b/roles/migrationcontroller/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart velero
-  include: restart_velero.yml
+  include_tasks: restart_velero.yml
 
 - name: restart restic
-  include: restart_restic.yml
+  include_tasks: restart_restic.yml


### PR DESCRIPTION
I am seeing an error:

```
TASK [migrationcontroller : Set up velero controller] **************************
task path: /opt/ansible/roles/migrationcontroller/tasks/main.yml:147
ERROR! The requested handler 'restart velero' was not found in either the main handlers list nor in the listening handlers list
```
This looks a lot like the following, although given the age I would expect this to be fixed in 2.8.7, which the operator currently has.
https://github.com/ansible/ansible/issues/34505

I'm trying to change it to include_tasks instead to see if it works better, but it's grasping.

https://github.com/ansible/ansible/issues/33784 is also mentioned about a possible difference in path value being required, but I think this is fixed.