### PR TITLE
add missing role perms for operator

### DIFF
--- a/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
@@ -221,6 +221,14 @@ spec:
       - serviceAccountName: migration-operator
         rules:
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - list
+          - get
+          - create
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/deploy/olm-catalog/mig-operator/v1.1.0/mig-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/v1.1.0/mig-operator.v1.1.0.clusterserviceversion.yaml
@@ -291,6 +291,14 @@ spec:
       - serviceAccountName: migration-operator
         rules:
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - list
+          - get
+          - create
+        - apiGroups:
           - ""
           resources:
           - configmaps


### PR DESCRIPTION
Seeing errors from the operator. Not sure if there's a regression or this was introduced with monitoring:
```
E0106 21:36:21.661233       6 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:196: Failed to list *unstructured.Unstructured: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:openshift-migration:migration-operator" cannot list resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "openshift-migration"
```