### PR TITLE
Fix servicemonitor patch failure

### DIFF
--- a/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/latest/mig-operator.latest.clusterserviceversion.yaml
@@ -281,6 +281,8 @@ spec:
           - list
           - get
           - create
+          - update
+          - patch
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/olm-catalog/mig-operator/v1.1.0/mig-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/mig-operator/v1.1.0/mig-operator.v1.1.0.clusterserviceversion.yaml
@@ -273,6 +273,8 @@ spec:
           - list
           - get
           - create
+          - update
+          - patch
         - apiGroups:
           - apps
           resourceNames:


### PR DESCRIPTION
There is a task failing trying to update a servicemonitor:
```
TASK [migrationcontroller : Set up mig controller monitoring config, ignoring failure on <3.11] ***
task path: /opt/ansible/roles/migrationcontroller/tasks/main.yml:180
fatal: [localhost]: FAILED! => {"changed": false, "error": 403, "msg": "Failed to patch object: {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"servicemonitors.monitoring.coreos.com \\\"mig-controller\\\" is forbidden: User \\\"system:serviceaccount:openshift-migration:migration-operator\\\" cannot patch resource \\\"servicemonitors\\\" in API group \\\"monitoring.coreos.com\\\" in the namespace \\\"openshift-migration\\\"\",\"reason\":\"Forbidden\",\"details\":{\"name\":\"mig-controller\",\"group\":\"monitoring.coreos.com\",\"kind\":\"servicemonitors\"},\"code\":403}\n", "reason": "Forbidden", "status": 403}
...ignoring
```
It's not super obvious because it's set up to ignore failures. I'm going to change this tasks to only run if the apigroup exists. We know how to do this for example when a resource type exists in openshift but not in kubernetes, etc. and we don't want to try to create it where it doesn't. It seems like the way to go.