### PR TITLE
Add RBAC rules for getting pod logs to MigController Role

### DIFF
--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -108,7 +108,12 @@ rules:
   - create
   - update
   - patch
-  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - '*'
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This is needed for non-OLM on OCP 4 and OCP 3.