### PR TITLE
Set up a symlink to a CA bundle when the Velero/Restic pods start

### DIFF
--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -56,6 +56,8 @@ spec:
               mountPath: /plugins
             - name: scratch
               mountPath: /scratch
+            - name: certs
+              mountPath: /etc/ssl/certs
           env:
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
@@ -80,6 +82,8 @@ spec:
         - name: plugins
           emptyDir: {}
         - name: scratch
+          emptyDir: {}
+        - name: certs
           emptyDir: {}
       initContainers:
         - image: {{ velero_plugin_image }}:{{ velero_plugin_version }}
@@ -118,6 +122,23 @@ spec:
           volumeMounts:
           - mountPath: /target
             name: plugins
+        - image: {{ velero_image }}:{{ velero_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: setup-certificate-secret
+          command:
+          - sh
+          - '-ec'
+          - >-
+            cp /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem
+            /certs/ca_bundle.pem;
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /certs
+            name: certs
+          - mountPath: /credentials
+            name: cloud-credentials
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -151,6 +172,8 @@ spec:
             path: {{ restic_pv_host_path }}
         - name: scratch
           emptyDir: {}
+        - name: certs
+          emptyDir: {}
       containers:
         - name: velero
           securityContext:
@@ -174,6 +197,8 @@ spec:
               mountPropagation: HostToContainer
             - name: scratch
               mountPath: /scratch
+            - name: certs
+              mountPath: /etc/ssl/certs
           env:
             - name: NODE_NAME
               valueFrom:
@@ -191,4 +216,22 @@ spec:
               value: /credentials-azure/cloud
             - name: VELERO_SCRATCH_DIR
               value: /scratch
+      initContainers:
+        - image: {{ velero_image }}:{{ velero_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: setup-certificate-secret
+          command:
+            - sh
+            - '-ec'
+            - >-
+              cp /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem
+              /certs/ca_bundle.pem;
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: cloud-credentials
+              mountPath: /credentials
 


### PR DESCRIPTION
This uses init containers to set up a symlink in the container's system certificate store (`/etc/ssl/certs`) that points to the ca bundle which is included in the AWS credential secret. Since it's a symlink, this gets updated when the cloud secret gets updated, allowing the Velero and Restic pods to trust whatever certificate is assigned in the relevant MigStorage's BackupStorageConfig at the time.

See Also:
- https://github.com/fusor/mig-controller/pull/402 - the corresponding controller PR to put the CA bundle in the secret
- https://gist.github.com/mansam/54b2b60a73c0b68e54e4bd4303d8acfe for a detailed explanation of the how and why of what this is doing.