### PR TITLE
Make noobaa requests configurable

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -68,3 +68,7 @@ noobaa_admin_secret: noobaa-admin
 noobaa_system_namespace: "{{ mig_namespace }}"
 noobaa_mig_bucket_name: mig-storage
 noobaa_s3_endpoint_proto: http
+noobaa_system_core_cpu: 0.5
+noobaa_system_core_mem: 500Mi
+noobaa_system_db_cpu: 0.5
+noobaa_system_db_mem: 1Gi

--- a/roles/migrationcontroller/templates/noobaa_system.yml.j2
+++ b/roles/migrationcontroller/templates/noobaa_system.yml.j2
@@ -6,4 +6,12 @@ metadata:
   labels:
     app: openshift-migration-noobaa
   namespace: {{ noobaa_system_namespace }}
-spec: {}
+spec:
+ dbResources:
+   requests:
+     cpu: {{ noobaa_system_db_cpu }}
+     memory: {{ noobaa_system_db_mem }}
+ coreResources:
+   requests:
+     cpu: {{ noobaa_system_core_cpu }}
+     memory: {{ noobaa_system_core_mem }}


### PR DESCRIPTION
We will likely have constrained resources on some clusters and NooBaa's default requests prevent the nooba-core pod to start on a 3 worker cluster. With this PR we can decrease (or increase) the requests so we can launch NooBaa when less resources are available.  