### PR TITLE
Bug 2015603: Exclude openshift rolebindings

### DIFF
--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -33,6 +33,7 @@ service catalog resources or OLM resources, OLM migration is not handled by Cran
   - operatorgroups
   - events
   - events.events.k8s.io
+  - rolebindings.authorization.openshift.io
 ```
 
 **Note:** For more granular information on this topic please refer the [Velero docs.](https://velero.io/docs/v1.4/how-velero-works/)

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -21,6 +21,7 @@ excluded_resources:
   - operatorgroups
   - events
   - events.events.k8s.io
+  - rolebindings.authorization.openshift.io
 proxy_secret_name: "migration-proxy"
 http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"


### PR DESCRIPTION
**Description**

* exclude rolebindings.authorization.openshift.io by default

* update docs

(cherry picked from commit 6a80a1020151fe92fbdc1b695bd0f8da002ab125)

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
