### PR TITLE
fix(Error): add prunes bundle crane-operator.v1.6.0

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.6.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.6.2.clusterserviceversion.yaml
@@ -230,6 +230,7 @@ metadata:
 spec:
   skips:
   - crane-operator.v1.6.1
+  - crane-operator.v1.6.0
   relatedImages:
   - name: controller
     image: quay.io/konveyor/mig-controller:latest


### PR DESCRIPTION
Error: add prunes bundle crane-operator.v1.6.0
(kind-registry:5000/test-operator/crane-operator:v1.6.0) from package
crane-operator, channel release-v1.6: this may be due to incorrect
channel head (crane-operator.v1.6.1, skips/replaces [])

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
