### PR TITLE
Bump version to 1.8.14

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.8.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.8.clusterserviceversion.yaml
@@ -2,11 +2,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: crane-operator.v1.8.13
+  name: crane-operator.v1.8.14
   namespace: openshift-migration
   annotations:
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.20"}]'
-    olm.skipRange: '>=0.0.0 <1.8.13'
+    olm.skipRange: '>=0.0.0 <1.8.14'
     capabilities: Seamless Upgrades
     description: Facilitates migration of container workloads from OpenShift 3.x to OpenShift 4.x
     categories: 'Modernization & Migration, OpenShift Optional'
@@ -155,6 +155,7 @@ spec:
   - mtc-operator.v1.8.10
   - mtc-operator.v1.8.11
   - mtc-operator.v1.8.12
+  - mtc-operator.v1.8.13
   relatedImages:
   - name: operator
     image: quay.io/konveyor/mig-operator-container:release-1.8

--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.8.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.8.clusterserviceversion.yaml
@@ -210,7 +210,7 @@ spec:
     url: https://github.com/konveyor/mig-operator
 
   labels:
-    alm-status-descriptors: crane-operator.v1.8.13
+    alm-status-descriptors: crane-operator.v1.8.14
     alm-owner-prometheus: crane-operator
 
   selector:
@@ -709,7 +709,7 @@ spec:
               - name: runner
                 emptyDir: {}
   maturity: alpha
-  version: 1.8.13
+  version: 1.8.14
   customresourcedefinitions:
     owned:
     - name: directvolumemigrations.migration.openshift.io

--- a/deploy/olm-catalog/bundle/mtc-operator.package.yaml
+++ b/deploy/olm-catalog/bundle/mtc-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: mtc-operator
 channels:
 - name: release-v1.8
-  currentCSV: mtc-operator.1.8.13
+  currentCSV: mtc-operator.1.8.14
 defaultChannel: release-v1.8

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -55,7 +55,7 @@ mig_controller_image_fqin: "{{ lookup('env', 'RELATED_IMAGE_CONTROLLER') }}"
 mig_controller_enable_cache: false
 discovery_collect_events: true
 discovery_volume_path: "/var/cache/discovery"
-mig_operator_version: "1.8.13"
+mig_operator_version: "1.8.14"
 mig_pv_move_storageclasses: []
 mig_pv_limit: "100"
 mig_pod_limit: "100"


### PR DESCRIPTION
This PR bumps the MTC operator version from 1.8.13 to 1.8.14

Changes include:
Updated currentCSV in the package manifest.
Updated name, version, and replaces in the ClusterServiceVersion.
Updated default image tags in the migrationcontroller role.