### PR TITLE
Upgrade urllib3 and pyasn1 to address Python CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,6 @@
 FROM quay.io/operator-framework/ansible-operator:v1.31
 USER root
+RUN pip3.8 --no-cache install --upgrade 'urllib3>=2.7.0'
 RUN pip3.8 --no-cache install -U openshift
 USER ansible
 COPY watches.yaml ${HOME}/watches.yaml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/operator-framework/ansible-operator:v1.31
 USER root
-RUN pip3.8 --no-cache install --upgrade 'urllib3>=2.7.0'
+RUN pip3.8 --no-cache install --upgrade 'urllib3>=2.7.0' 'pyasn1>=0.6.3'
 RUN pip3.8 --no-cache install -U openshift
 USER ansible
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
## Summary

Upgrades Python packages in the final stage to address 6 CVEs:

**urllib3** (>= 2.7.0):
- CVE-2025-66418, CVE-2025-66471, CVE-2026-21441, CVE-2026-44431

**pyasn1** (>= 0.6.3):
- CVE-2026-23490 (DoS via malformed RELATIVE-OID)
- CVE-2026-30922 (DoS via unbounded recursion)

## Jira tickets
MIG-1814, MIG-1832, MIG-1838, MIG-1916, MIG-1905, MIG-1882

## Test plan
- [ ] Verify built image contains urllib3 >= 2.7.0, pyasn1 >= 0.6.3